### PR TITLE
Update icon cache

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,3 +11,6 @@ config_h_dir = include_directories('.')
 
 subdir('data')
 subdir('src')
+
+meson.add_install_script('meson/post_install.py')
+

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -5,7 +5,6 @@ import subprocess
 
 prefix = os.environ.get('MESON_INSTALL_PREFIX', '/usr/local')
 datadir = os.path.join(prefix, 'share')
-schemadir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
 
 # Packaging tools define DESTDIR and this isn't needed for them
 if 'DESTDIR' not in os.environ:

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+prefix = os.environ.get('MESON_INSTALL_PREFIX', '/usr/local')
+datadir = os.path.join(prefix, 'share')
+schemadir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
+
+# Packaging tools define DESTDIR and this isn't needed for them
+if 'DESTDIR' not in os.environ:
+    print('Updating icon cache...')
+    icon_cache_dir = os.path.join(datadir, 'icons', 'hicolor')
+    if not os.path.exists(icon_cache_dir):
+        os.makedirs(icon_cache_dir)
+    subprocess.call(['gtk-update-icon-cache', '-qtf', icon_cache_dir])
+
+    print('Updating desktop database...')
+    desktop_database_dir = os.path.join(datadir, 'applications')
+    if not os.path.exists(desktop_database_dir):
+        os.makedirs(desktop_database_dir)
+    subprocess.call(['update-desktop-database', '-q', desktop_database_dir])
+


### PR DESCRIPTION
This updates the icon cache and desktop database when installing with Meson, like most elementary apps do. This ensures the correct icon will show up both in the app and in the app launcher.