### PR TITLE
Include fonts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "src/github.com/writeas/writeas-cli"]
 	path = src/github.com/writeas/writeas-cli
 	url = https://github.com/writeas/writeas-cli.git
-[submodule "fonts/lora"]
-	path = fonts/lora
-	url = https://code.as/writeas/fonts-lora.git
-	branch = include

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "src/github.com/writeas/writeas-cli"]
 	path = src/github.com/writeas/writeas-cli
 	url = https://github.com/writeas/writeas-cli.git
+[submodule "fonts/lora"]
+	path = fonts/lora
+	url = https://code.as/writeas/fonts-lora.git
+	branch = include

--- a/debian/control
+++ b/debian/control
@@ -14,5 +14,5 @@ Standards-Version: 3.9.3
 Package: com.github.writeas.writeas-gtk
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Recommends: fonts-lora, fonts-open-sans, fonts-hack
+Recommends: fonts-open-sans, fonts-hack
 Description: A distraction free and private writing tool, with built-in publishing.

--- a/debian/control
+++ b/debian/control
@@ -14,5 +14,5 @@ Standards-Version: 3.9.3
 Package: com.github.writeas.writeas-gtk
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Recommends: fonts-open-sans, fonts-hack
+Recommends: fonts-open-sans, fonts-hack-ttf
 Description: A distraction free and private writing tool, with built-in publishing.

--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,4 @@ run_target('build', command: 'build-cli.sh')
 
 subdir('data')
 subdir('src')
+subdir('fonts/lora')


### PR DESCRIPTION
This includes the Lora (serif) font in the package and use the `fonts-hack-ttf` package, as listed in the [Hack repo](https://github.com/source-foundry/Hack#package-managers). I was able to install with `fonts-hack` on elementaryOS Juno, but hopefully this fixes the issue.

If so, this closes #7.